### PR TITLE
Validate that file exists when using 'start' in CLI

### DIFF
--- a/OperatingSystem/ProcessManagement/Processes/CLIProc.cs
+++ b/OperatingSystem/ProcessManagement/Processes/CLIProc.cs
@@ -94,6 +94,11 @@ public class CLIProc : ProcessProgram
                         return 1;
                     }
 
+                    if (!FileSystem.FileExists(_inputTokens[1])) {
+                        PrintMessage($"File not found: {_inputTokens[1]}");
+                        return 1;
+                    }
+
                     if (_inputTokens.Count > 2 && !String.IsNullOrEmpty(_inputTokens[2]) && byte.TryParse(_inputTokens[2], out byte priority)) {
                         LoadProgram(_inputTokens[1], basePriority: priority);
                     }


### PR DESCRIPTION
Previously, if you typed wrong program file while starting process, the program would crash.